### PR TITLE
Add Avax receipts logic

### DIFF
--- a/bin/run_avax.sh
+++ b/bin/run_avax.sh
@@ -1,0 +1,8 @@
+ #! /bin/sh
+export DRY_RUN=0
+export NODE_URL=http://avalanche-hz.stage.san:32080/ext/bc/C/rpc
+export GET_RECEIPTS_ENDPOINT=eth_getTransactionReceipt
+export START_BLOCK=0
+export KAFKA_TOPIC=avax_receipts
+export AVAX=1
+docker-compose -f ./docker/docker-compose.yml up --build

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -26,6 +26,8 @@ services:
       ZOOKEEPER_URL: zookeeper:2181
       NODE_URL: "${NODE_URL}"
       START_BLOCK: "${START_BLOCK}"
+      KAFKA_TOPIC: "${KAFKA_TOPIC}"
+      AVAX: "${AVAX}"
       GET_RECEIPTS_ENDPOINT: "${GET_RECEIPTS_ENDPOINT}"
       DRY_RUN: "${DRY_RUN}"
     entrypoint: "/bin/sh"

--- a/helper.js
+++ b/helper.js
@@ -26,15 +26,14 @@ const setReceiptsTimestamp = (receipts, timestamps) => {
   return collection.forEach(receipts, receipt =>  receipt['timestamp'] = timestamps[receipt.blockNumber])
 }
 
-const parseReceipts = (responses, avax) => {
+const parseTransactionReceipts = (responses) => {
   const receipts = responses.map((response) => response['result'])
-  if (!avax){
-    return array.compact(array.flatten(receipts))
-  }
-  else{
-    return receipts
-  }
+  return receipts
+}
 
+const parseReceipts = (responses) => {
+  const receipts = responses.map((response) => response['result'])
+  return array.compact(array.flatten(receipts))
 }
 
 const decodeReceipt = (receipt) => {
@@ -79,6 +78,7 @@ function decodeLog(log) {
 module.exports = {
   parseEthBlocks: parseEthBlocks,
   parseReceipts: parseReceipts,
+  parseTransactionReceipts: parseTransactionReceipts,
   decodeReceipt: decodeReceipt,
   decodeBlock: decodeBlock,
   prepareBlockTimestampsObject: prepareBlockTimestampsObject,

--- a/helper.js
+++ b/helper.js
@@ -26,9 +26,15 @@ const setReceiptsTimestamp = (receipts, timestamps) => {
   return collection.forEach(receipts, receipt =>  receipt['timestamp'] = timestamps[receipt.blockNumber])
 }
 
-const parseReceipts = (responses) => {
+const parseReceipts = (responses, avax) => {
   const receipts = responses.map((response) => response['result'])
-  return array.compact(array.flatten(receipts))
+  if (!avax){
+    return array.compact(array.flatten(receipts))
+  }
+  else{
+    return receipts
+  }
+
 }
 
 const decodeReceipt = (receipt) => {


### PR DESCRIPTION
Modifying the receipts exporter to support the chains that do not have API method to export all receipts from a block, but have method to get receipt from transaction hash. 