### PR TITLE
Making small adjustments to exporter

### DIFF
--- a/bin/run_bnb.sh
+++ b/bin/run_bnb.sh
@@ -1,6 +1,6 @@
  #! /bin/sh
 export DRY_RUN=0
-export NODE_URL=http://erigon-bsc-hz.stage.san:30250
+export NODE_URL=http://erigon-bsc-hz.stage.san:32080
 export GET_RECEIPTS_ENDPOINT=eth_getBlockReceipts
 export START_BLOCK=0
 docker-compose -f ./docker/docker-compose.yml up --build

--- a/helper.js
+++ b/helper.js
@@ -1,8 +1,9 @@
-const Web3 = require('web3')
-const lang = require('lodash/lang')
-const array = require('lodash/array')
-const collection = require('lodash/collection')
-const object = require('lodash/object')
+const Web3 = require("web3")
+const lang = require("lodash/lang")
+const array = require("lodash/array")
+const collection = require("lodash/collection")
+const object = require("lodash/object")
+
 
 const parseEthBlocks = (responses) => {
   return responses.map((response) => response["result"])
@@ -23,11 +24,11 @@ const prepareBlockTimestampsObject = (blocks) => {
 }
 
 const setReceiptsTimestamp = (receipts, timestamps) => {
-  return collection.forEach(receipts, receipt =>  receipt['timestamp'] = timestamps[receipt.blockNumber])
+  return collection.forEach(receipts, receipt =>  receipt["timestamp"] = timestamps[receipt.blockNumber])
 }
 
 const parseReceipts = (responses) => {
-  const receipts = responses.map((response) => response['result'])
+  const receipts = responses.map((response) => response["result"])
   return array.compact(array.flatten(receipts))
 }
 

--- a/index.js
+++ b/index.js
@@ -34,7 +34,7 @@ const jayson = require("jayson/promise")
 const parityClient = jayson.client.http(NODE_URL)
 
 const fetchEthReceipts = (fromBlock, toBlock) => {
-  var batch = []
+  const batch = []
   for (fromBlock; fromBlock < toBlock + 1; fromBlock++) {
     batch.push(
       parityClient.request(
@@ -49,7 +49,7 @@ const fetchEthReceipts = (fromBlock, toBlock) => {
 }
 
 const fetchEthBlockTimestamps = (fromBlock, toBlock) => {
-  var batch = []
+  const batch = []
   for (fromBlock; fromBlock < toBlock + 1; fromBlock++) {
     batch.push(
       parityClient.request(
@@ -93,14 +93,14 @@ async function work() {
 
     if (receipts.length > 0) {
       logger.info(`Storing ${receipts.length} messages for blocks ${lastProcessedBlock + 1}:${toBlock}`)
-      if (DRY_RUN !== 1){
+      if (DRY_RUN !== 1) {
         await exporter.sendDataWithKey(receipts, "transactionHash")
       }
     }
 
     lastProcessedBlock = toBlock
     metrics.lastExportedBlock.set(lastProcessedBlock)
-    if (DRY_RUN !== 1){
+    if (DRY_RUN !== 1) {
       await exporter.savePosition(lastProcessedBlock)
     }
   }
@@ -120,13 +120,13 @@ const fetchReceipts = () => {
 }
 
 async function fetchLastImportedBlock() {
-  const lastPosition = await exporter.getLastPosition()
+  const lastPosition = parseInt(await exporter.getLastPosition())
 
   if (lastPosition) {
     lastProcessedBlock = lastPosition
     logger.info(`Resuming export from position ${JSON.stringify(lastPosition)}`)
   } else {
-    if (DRY_RUN !== 1){
+    if (DRY_RUN !== 1) {
       await exporter.savePosition(lastProcessedBlock)
     }
     logger.info(`Initialized exporter with initial position ${JSON.stringify(lastProcessedBlock)}`)


### PR DESCRIPTION
There are two main things that have been changed here that are not some styling stuff:
1. Correcting the port for the node URL in the `run_bnb.sh` file
2. Parsing the lastPosition as an integer, not leaving it as a string. Looking deeper into the [kafka storage](https://github.com/santiment/san-chain-exporter/blob/master/lib/kafka_storage.js#L133) file, it seems that the lastPosition is being assigned as a string or null, instead of as an integer, which kind of breaks at the `work()` function a little higher above. I think this is the underlying cause of the "empty batch" issue with the BSC receipts, tested it out before as a string and I got to reproduce it, parsed it as an integer and it worked